### PR TITLE
pipe: callback error comments

### DIFF
--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,0 +1,24 @@
+const tape = require('tape')
+const { Readable, Writable } = require('../')
+
+tape('pipe with callback - error case', function (t) {
+  const buffered = []
+
+  const r = new Readable()
+  const w = new Writable({
+    write (data, cb) {
+      cb(new Error('blerg'))
+    }
+  })
+
+  r.pipe(w, function (err) {
+    t.pass('callback called')
+    t.same(err, null)
+    t.same(buffered, [ 'hello', 'world' ])
+    t.end()
+  })
+
+  r.push('hello')
+  r.push('world')
+  r.push(null)
+})


### PR DESCRIPTION
not sure if missing feature or probably not implemented yet...

on error in the writeable consumer, i would have expected the callback for `.pipe()` to receive the error via callback. right now it just throws.

```
$ node test/pipe.js
TAP version 13
# pipe with callback - error case
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: blerg
    at Writable.write [as _write] (/Users/robert/stable-stream/test/pipe.js:10:10)
    at WritableState.update (/Users/robert/stable-stream/index.js:148:14)
    at updateWriteNT (/Users/robert/stable-stream/index.js:429:6)
    at process._tickCallback (internal/process/next_tick.js:63:19)
Emitted 'error' event at:
    at WritableState.afterDestroy (/Users/stable-stream/index.js:399:19)
    at Writable._destroy (/Users/robert/stable-stream/index.js:478:5)
    at WritableState.updateNonPrimary (/Users/robert/stable-stream/index.js:167:16)
    at WritableState.update (/Users/robert/stable-stream/index.js:152:70)
    at updateWriteNT (/Users/robert/stable-stream/index.js:429:6)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```