### PR TITLE
Pass Writable opts to super

### DIFF
--- a/index.js
+++ b/index.js
@@ -620,7 +620,7 @@ class Readable extends Stream {
 
 class Writable extends Stream {
   constructor (opts) {
-    super()
+    super(opts)
 
     this._duplexState |= OPENING | READ_DONE
     this._writableState = new WritableState(this, opts)

--- a/test/writable.js
+++ b/test/writable.js
@@ -1,0 +1,23 @@
+const tape = require('tape')
+const { Writable } = require('../')
+
+tape('opens before writes', function (t) {
+  t.plan(2)
+  const trace = []
+  const stream = new Writable({
+    open (cb) {
+      trace.push('open')
+      return cb(null)
+    },
+    write (data, cb) {
+      trace.push('write')
+      return cb(null)
+    }
+  })
+  stream.on('close', () => {
+    t.equals(trace.length, 2)
+    t.equals(trace[0], 'open')
+  })
+  stream.write('data')
+  stream.end()
+})


### PR DESCRIPTION
This change allows implementers of writable streams to provide custom implementations of `_open` and `_destroy` as properties on the `opts` object passed to `Writable`.