### PR TITLE
PassThrough support

### DIFF
--- a/index.js
+++ b/index.js
@@ -854,5 +854,6 @@ module.exports = {
   Readable,
   Duplex,
   Transform,
+  // Export PassThrough for compatibility with Node.js core's stream module
   PassThrough
 }

--- a/index.js
+++ b/index.js
@@ -822,6 +822,8 @@ class Transform extends Duplex {
   }
 }
 
+class PassThrough extends Transform {}
+
 function transformAfterFlush (err, data) {
   const cb = this._transformState.afterFinal
   if (err) return cb(err)
@@ -851,5 +853,6 @@ module.exports = {
   Writable,
   Readable,
   Duplex,
-  Transform
+  Transform,
+  PassThrough
 }

--- a/test/passthrough.js
+++ b/test/passthrough.js
@@ -1,0 +1,22 @@
+const tape = require('tape')
+const { PassThrough, Writable, Readable } = require('../')
+
+tape('passthrough', t => {
+  let i = 0
+  const p = new PassThrough()
+  const w = new Writable({
+    write (data, cb) {
+      i++
+      if (i === 1) t.equal(data, 'foo')
+      else if (i === 2) t.equal(data, 'bar')
+      else t.fail('too many messages')
+      cb()
+    }
+  })
+  w.on('finish', () => t.end())
+  const r = new Readable()
+  r.pipe(p).pipe(w)
+  r.push('foo')
+  r.push('bar')
+  r.push(null)
+})


### PR DESCRIPTION
NodeJS has in newer versions a [`PassThrough` stream](https://nodejs.org/api/stream.html#stream_class_stream_passthrough) that is a transform stream that simply forwards. This simply adds this to streamx so that code that uses it can easily switch from stream to streamx.