### PR TITLE
allow async iterator to be already aborted.

### DIFF
--- a/index.js
+++ b/index.js
@@ -522,6 +522,9 @@ class Stream extends EventEmitter {
       if (opts.destroy) this._destroy = opts.destroy
       if (opts.predestroy) this._predestroy = opts.predestroy
       if (opts.signal) {
+        if (opts.signal.aborted) {
+          throw new Error('Stream aborted.')
+        }
         opts.signal.addEventListener('abort', abort.bind(this))
       }
     }

--- a/test/async-iterator.js
+++ b/test/async-iterator.js
@@ -170,3 +170,15 @@ tape('using abort controller', async function (t) {
   t.same(inc, [0])
   t.end()
 })
+tape('using aborted abort controller', async function (t) {
+  const controller = new AbortController()
+  controller.abort()
+  t.plan(1)
+  try {
+    /* eslint-disable-next-line */
+    new Readable({ signal: controller.signal })
+  } catch (err) {
+    t.same(err.message, 'Stream aborted.')
+  }
+  t.end()
+})

--- a/test/async-iterator.js
+++ b/test/async-iterator.js
@@ -158,6 +158,8 @@ tape('using abort controller', async function (t) {
     return r
   }
   const controller = new AbortController()
+  let removeCalled = false
+  beforeFn(controller.signal, 'removeEventListener', () => { removeCalled = true })
   const inc = []
   setTimeout(() => controller.abort(), 10)
   try {
@@ -167,8 +169,17 @@ tape('using abort controller', async function (t) {
   } catch (err) {
     t.same(err.message, 'Stream aborted.')
   }
+  t.same(removeCalled, true)
   t.same(inc, [0])
   t.end()
+
+  function beforeFn (obj, fnName, handler) {
+    const orig = obj[fnName]
+    obj[fnName] = function () {
+      handler.apply(this, arguments)
+      orig.apply(this, arguments)
+    }
+  }
 })
 tape('using aborted abort controller', async function (t) {
   const controller = new AbortController()


### PR DESCRIPTION
I noticed that a signal can be aborted when being passed-in. This PR checks if the signal is aborted and throws an error.