### PR TITLE
Make read ahead configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ Options include:
   map: (data) => data, // optional function to map input data
   byteLength: (data) => size, // optional function that calculates the byte size of input data
   signal: abortController.signal, // optional AbortSignal that triggers `.destroy` when on `abort`
-  eagerOpen: false, // eagerly open the stream
-  readAhead: true // should the stream read ahead (default) or wait for the user to empty the buffer first
+  eagerOpen: false // eagerly open the stream
 }
 ```
 
@@ -122,6 +121,9 @@ the constructor instead of overwrite the methods below.
 The default byteLength function returns the byte length of buffers and `1024`
 for any other object. This means the buffer will contain around 16 non buffers
 or buffers worth 16kb when full if the defaults are used.
+
+If you set highWaterMark to `0` then all read ahead buffering on the stream
+is disabled and it will only call `_read` when a user reads rather than ahead of time.
 
 #### `rs._read(cb)`
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Options include:
   map: (data) => data, // optional function to map input data
   byteLength: (data) => size, // optional function that calculates the byte size of input data
   signal: abortController.signal, // optional AbortSignal that triggers `.destroy` when on `abort`
-  eagerOpen: false // eagerly open the stream
+  eagerOpen: false, // eagerly open the stream
+  readAhead: true // should the stream read ahead (default) or wait for the user to empty the buffer first
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -232,12 +232,12 @@ class WritableState {
 }
 
 class ReadableState {
-  constructor (stream, { readAhead = true, highWaterMark = 16384, map = null, mapReadable, byteLength, byteLengthReadable } = {}) {
+  constructor (stream, { highWaterMark = 16384, map = null, mapReadable, byteLength, byteLengthReadable } = {}) {
     this.stream = stream
     this.queue = new FIFO()
-    this.highWaterMark = highWaterMark
+    this.highWaterMark = highWaterMark === 0 ? 1 : highWaterMark
     this.buffered = 0
-    this.readAhead = readAhead
+    this.readAhead = highWaterMark > 0
     this.error = null
     this.pipeline = null
     this.byteLength = byteLengthReadable || byteLength || defaultByteLength
@@ -681,7 +681,7 @@ class Readable extends Stream {
     this._readableState = new ReadableState(this, opts)
 
     if (opts) {
-      if (opts.readAhead === false) this._duplexState &= READ_NO_READ_AHEAD
+      if (this._readableState.readAhead === false) this._duplexState &= READ_NO_READ_AHEAD
       if (opts.read) this._read = opts.read
       if (opts.eagerOpen) this._readableState.updateNextTick()
     }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const FIFO = require('fast-fifo')
 
 /* eslint-disable no-multi-spaces */
 
-// 27 bits used total (4 from shared, 13 from read, and 10 from write)
-const MAX = ((1 << 27) - 1)
+// 28 bits used total (4 from shared, 14 from read, and 10 from write)
+const MAX = ((1 << 28) - 1)
 
 // Shared state
 const OPENING       = 0b0001
@@ -20,25 +20,27 @@ const NOT_OPENING = MAX ^ OPENING
 const NOT_PREDESTROYING = MAX ^ PREDESTROYING
 
 // Read state (4 bit offset from shared state)
-const READ_ACTIVE           = 0b0000000000001 << 4
-const READ_UPDATING         = 0b0000000000010 << 4
-const READ_PRIMARY          = 0b0000000000100 << 4
-const READ_QUEUED           = 0b0000000001000 << 4
-const READ_RESUMED          = 0b0000000010000 << 4
-const READ_PIPE_DRAINED     = 0b0000000100000 << 4
-const READ_ENDING           = 0b0000001000000 << 4
-const READ_EMIT_DATA        = 0b0000010000000 << 4
-const READ_EMIT_READABLE    = 0b0000100000000 << 4
-const READ_EMITTED_READABLE = 0b0001000000000 << 4
-const READ_DONE             = 0b0010000000000 << 4
-const READ_NEXT_TICK        = 0b0100000000000 << 4
-const READ_NEEDS_PUSH       = 0b1000000000000 << 4
+const READ_ACTIVE           = 0b00000000000001 << 4
+const READ_UPDATING         = 0b00000000000010 << 4
+const READ_PRIMARY          = 0b00000000000100 << 4
+const READ_QUEUED           = 0b00000000001000 << 4
+const READ_RESUMED          = 0b00000000010000 << 4
+const READ_PIPE_DRAINED     = 0b00000000100000 << 4
+const READ_ENDING           = 0b00000001000000 << 4
+const READ_EMIT_DATA        = 0b00000010000000 << 4
+const READ_EMIT_READABLE    = 0b00000100000000 << 4
+const READ_EMITTED_READABLE = 0b00001000000000 << 4
+const READ_DONE             = 0b00010000000000 << 4
+const READ_NEXT_TICK        = 0b00100000000000 << 4
+const READ_NEEDS_PUSH       = 0b01000000000000 << 4
+const READ_READ_AHEAD       = 0b10000000000000 << 4
 
 // Combined read state
 const READ_FLOWING = READ_RESUMED | READ_PIPE_DRAINED
 const READ_ACTIVE_AND_NEEDS_PUSH = READ_ACTIVE | READ_NEEDS_PUSH
 const READ_PRIMARY_AND_ACTIVE = READ_PRIMARY | READ_ACTIVE
 const READ_EMIT_READABLE_AND_QUEUED = READ_EMIT_READABLE | READ_QUEUED
+const READ_RESUMED_READ_AHEAD = READ_RESUMED | READ_READ_AHEAD
 
 const READ_NOT_ACTIVE             = MAX ^ READ_ACTIVE
 const READ_NON_PRIMARY            = MAX ^ READ_PRIMARY
@@ -50,18 +52,20 @@ const READ_NOT_ENDING             = MAX ^ READ_ENDING
 const READ_PIPE_NOT_DRAINED       = MAX ^ READ_FLOWING
 const READ_NOT_NEXT_TICK          = MAX ^ READ_NEXT_TICK
 const READ_NOT_UPDATING           = MAX ^ READ_UPDATING
+const READ_NO_READ_AHEAD          = MAX ^ READ_READ_AHEAD
+const READ_PAUSED_NO_READ_AHEAD   = MAX ^ READ_RESUMED_READ_AHEAD
 
-// Write state (17 bit offset, 4 bit offset from shared state and 13 from read state)
-const WRITE_ACTIVE     = 0b0000000001 << 17
-const WRITE_UPDATING   = 0b0000000010 << 17
-const WRITE_PRIMARY    = 0b0000000100 << 17
-const WRITE_QUEUED     = 0b0000001000 << 17
-const WRITE_UNDRAINED  = 0b0000010000 << 17
-const WRITE_DONE       = 0b0000100000 << 17
-const WRITE_EMIT_DRAIN = 0b0001000000 << 17
-const WRITE_NEXT_TICK  = 0b0010000000 << 17
-const WRITE_WRITING    = 0b0100000000 << 17
-const WRITE_FINISHING  = 0b1000000000 << 17
+// Write state (18 bit offset, 4 bit offset from shared state and 13 from read state)
+const WRITE_ACTIVE     = 0b0000000001 << 18
+const WRITE_UPDATING   = 0b0000000010 << 18
+const WRITE_PRIMARY    = 0b0000000100 << 18
+const WRITE_QUEUED     = 0b0000001000 << 18
+const WRITE_UNDRAINED  = 0b0000010000 << 18
+const WRITE_DONE       = 0b0000100000 << 18
+const WRITE_EMIT_DRAIN = 0b0001000000 << 18
+const WRITE_NEXT_TICK  = 0b0010000000 << 18
+const WRITE_WRITING    = 0b0100000000 << 18
+const WRITE_FINISHING  = 0b1000000000 << 18
 
 const WRITE_NOT_ACTIVE    = MAX ^ (WRITE_ACTIVE | WRITE_WRITING)
 const WRITE_NON_PRIMARY   = MAX ^ WRITE_PRIMARY
@@ -88,7 +92,7 @@ const READ_PRIMARY_STATUS = OPEN_STATUS | READ_ENDING | READ_DONE
 const READ_STATUS = OPEN_STATUS | READ_DONE | READ_QUEUED
 const READ_ENDING_STATUS = OPEN_STATUS | READ_ENDING | READ_QUEUED
 const READ_READABLE_STATUS = OPEN_STATUS | READ_EMIT_READABLE | READ_QUEUED | READ_EMITTED_READABLE
-const SHOULD_NOT_READ = OPEN_STATUS | READ_ACTIVE | READ_ENDING | READ_DONE | READ_NEEDS_PUSH
+const SHOULD_NOT_READ = OPEN_STATUS | READ_ACTIVE | READ_ENDING | READ_DONE | READ_NEEDS_PUSH | READ_READ_AHEAD
 const READ_BACKPRESSURE_STATUS = DESTROY_STATUS | READ_ENDING | READ_DONE
 const READ_UPDATE_SYNC_STATUS = READ_UPDATING | OPEN_STATUS | READ_NEXT_TICK | READ_PRIMARY
 
@@ -228,11 +232,12 @@ class WritableState {
 }
 
 class ReadableState {
-  constructor (stream, { highWaterMark = 16384, map = null, mapReadable, byteLength, byteLengthReadable } = {}) {
+  constructor (stream, { readAhead = true, highWaterMark = 16384, map = null, mapReadable, byteLength, byteLengthReadable } = {}) {
     this.stream = stream
     this.queue = new FIFO()
     this.highWaterMark = highWaterMark
     this.buffered = 0
+    this.readAhead = readAhead
     this.error = null
     this.pipeline = null
     this.byteLength = byteLengthReadable || byteLength || defaultByteLength
@@ -322,6 +327,11 @@ class ReadableState {
       return data
     }
 
+    if (this.readAhead === false) {
+      stream._duplexState |= READ_READ_AHEAD
+      this.updateNextTick()
+    }
+
     return null
   }
 
@@ -343,7 +353,7 @@ class ReadableState {
     do {
       this.drain()
 
-      while (this.buffered < this.highWaterMark && (stream._duplexState & SHOULD_NOT_READ) === 0) {
+      while (this.buffered < this.highWaterMark && (stream._duplexState & SHOULD_NOT_READ) === READ_READ_AHEAD) {
         stream._duplexState |= READ_ACTIVE_AND_NEEDS_PUSH
         stream._read(this.afterRead)
         this.drain()
@@ -516,6 +526,7 @@ function afterWrite (err) {
 function afterRead (err) {
   if (err) this.stream.destroy(err)
   this.stream._duplexState &= READ_NOT_ACTIVE
+  if (this.readAhead === false && (this.stream._duplexState & READ_RESUMED) === 0) this.stream._duplexState &= READ_NO_READ_AHEAD
   this.updateCallback()
 }
 
@@ -573,7 +584,7 @@ function afterTransform (err, data) {
 function newListener (name) {
   if (this._readableState !== null) {
     if (name === 'data') {
-      this._duplexState |= (READ_EMIT_DATA | READ_RESUMED)
+      this._duplexState |= (READ_EMIT_DATA | READ_RESUMED_READ_AHEAD)
       this._readableState.updateNextTick()
     }
     if (name === 'readable') {
@@ -666,10 +677,11 @@ class Readable extends Stream {
   constructor (opts) {
     super(opts)
 
-    this._duplexState |= OPENING | WRITE_DONE
+    this._duplexState |= OPENING | WRITE_DONE | READ_READ_AHEAD
     this._readableState = new ReadableState(this, opts)
 
     if (opts) {
+      if (opts.readAhead === false) this._duplexState &= READ_NO_READ_AHEAD
       if (opts.read) this._read = opts.read
       if (opts.eagerOpen) this._readableState.updateNextTick()
     }
@@ -701,13 +713,13 @@ class Readable extends Stream {
   }
 
   resume () {
-    this._duplexState |= READ_RESUMED
+    this._duplexState |= READ_RESUMED_READ_AHEAD
     this._readableState.updateNextTick()
     return this
   }
 
   pause () {
-    this._duplexState &= READ_PAUSED
+    this._duplexState &= (this._readableState.readAhead === false ? READ_PAUSED_NO_READ_AHEAD : READ_PAUSED)
     return this
   }
 

--- a/test/readable.js
+++ b/test/readable.js
@@ -22,10 +22,6 @@ test('ondata', function (t) {
   })
 })
 
-function nextImmediate () {
-  return new Promise(resolve => setImmediate(resolve))
-}
-
 test('pause', async function (t) {
   const r = new Readable()
   const buffered = []
@@ -306,3 +302,59 @@ test('resume a stalled stream', function (t) {
     })
   })
 })
+
+test('no read-ahead with pause/resume', function (t) {
+  t.plan(4)
+
+  let tick = 0
+
+  const r = new Readable({
+    readAhead: false,
+    read (cb) {
+      this.push('tick: ' + (++tick))
+      cb()
+    }
+  })
+
+  r.once('data', function () {
+    t.is(tick, 1)
+    r.pause()
+    setImmediate(() => {
+      t.is(tick, 1)
+      r.resume()
+      r.once('data', function () {
+        t.is(tick, 2)
+        r.pause()
+        setImmediate(() => {
+          t.is(tick, 2)
+        })
+      })
+    })
+  })
+})
+
+test('no read-ahead with async iterator', async function (t) {
+  let tick = 0
+
+  const r = new Readable({
+    readAhead: false,
+    read (cb) {
+      this.push('tick: ' + (++tick))
+      if (tick === 10) this.push(null)
+      cb()
+    }
+  })
+
+  let expectedTick = 0
+  for await (const data of r) {
+    t.is(tick, ++expectedTick)
+    t.is(data, 'tick: ' + tick)
+    await nextImmediate()
+  }
+
+  t.is(expectedTick, 10)
+})
+
+function nextImmediate () {
+  return new Promise(resolve => setImmediate(resolve))
+}

--- a/test/readable.js
+++ b/test/readable.js
@@ -309,7 +309,7 @@ test('no read-ahead with pause/resume', function (t) {
   let tick = 0
 
   const r = new Readable({
-    readAhead: false,
+    highWaterMark: 0,
     read (cb) {
       this.push('tick: ' + (++tick))
       cb()
@@ -337,7 +337,7 @@ test('no read-ahead with async iterator', async function (t) {
   let tick = 0
 
   const r = new Readable({
-    readAhead: false,
+    highWaterMark: 0,
     read (cb) {
       this.push('tick: ' + (++tick))
       if (tick === 10) this.push(null)


### PR DESCRIPTION
Allows for disabling read-ahead meaning a _read only happens when someone asks for it and gets a cache-miss.

This is useful for interactive async iterators like

```js
import { Readable } from 'streamx'

const stream = new Readable({
  readAhead: false,
  read (cb) {
    this.push(new Date())
    cb(null)
  }
})

for await (const time of stream) {
  console.log(time) // poll is requested just in time rather than ahead of time
  await new Promise(resolve => setTimeout(resolve, 5000))
}
```