### PR TITLE
fix: use w3c decoder

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const PREMATURE_CLOSE = new Error('Premature close')
 
 const queueTick = require('queue-tick')
 const FIFO = require('fast-fifo')
-const TextDecoder = require('text-decoder')
 
 /* eslint-disable no-multi-spaces */
 
@@ -702,7 +701,15 @@ class Readable extends Stream {
     return this
 
     function mapOrSkip (data) {
-      const next = dec.push(data)
+      let next
+
+      try {
+        next = dec.decode(data, { stream: true })
+      } catch (error) {
+        // text decoder will throw error if it can't decode the data
+        next = data
+      }
+
       return next === '' ? null : map(next)
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "fast-fifo": "^1.3.2",
-    "queue-tick": "^1.0.1",
-    "text-decoder": "^1.1.0"
+    "queue-tick": "^1.0.1"
   },
   "devDependencies": {
     "b4a": "^1.6.6",


### PR DESCRIPTION
uses W3C text decoder which is built in to most JS environments such as node.js, web, bun etc

reduces dependency size by some 20-ish KB