### PR TITLE
Fix error handling when piping `streamx` with `node:stream`

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,9 +269,16 @@ class ReadableState {
       if (cb) pipeTo.on('error', noop) // We already error handle this so supress crashes
       pipeTo.on('finish', this.pipeline.finished.bind(this.pipeline)) // TODO: just call finished from pipeTo itself
     } else {
-      const onerror = this.pipeline.done.bind(this.pipeline, pipeTo)
       const onclose = this.pipeline.done.bind(this.pipeline, pipeTo, null) // onclose has a weird bool arg
-      pipeTo.on('error', onerror)
+      pipeTo.once('error', (err) => {
+        if (!cb) {
+          if (pipeTo.listenerCount('error') === 0) {
+            pipeTo.emit('error', err)
+          }
+        }
+
+        this.pipeline.done(pipeTo, err)
+      })
       pipeTo.on('close', onclose)
       pipeTo.on('finish', this.pipeline.finished.bind(this.pipeline))
     }

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -2,6 +2,28 @@ const test = require('brittle')
 const compat = require('stream')
 const { Readable, Writable } = require('../')
 
+test('pipe to node stream - error case', function (t) {
+  t.plan(1)
+
+  const expectedErr = new Error('blerg')
+  process.once('uncaughtException', function (err) {
+    t.is(err, expectedErr)
+  })
+
+  const r = new Readable()
+  const w = new compat.Writable({
+    write (data, enc, cb) {
+      cb(expectedErr)
+    }
+  })
+
+  r.push('hi')
+  r.push('ho')
+  r.push(null)
+
+  r.pipe(w)
+})
+
 test('pipe to node stream', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
Fixes #94.