### PR TITLE
fix: add PassThrough constructor for bare compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1029,7 +1029,11 @@ class Transform extends Duplex {
   }
 }
 
-class PassThrough extends Transform {}
+class PassThrough extends Transform {
+  constructor(opts) {
+    super(opts)
+  }
+}
 
 function transformAfterFlush (err, data) {
   const cb = this._transformState.afterFinal


### PR DESCRIPTION
In bare context if a PassThrough instance is created it requires its own constructor. Without it the error:

`PassThrough is not a constructor`

is thrown.

This allows streamx to be compatible with node modules using PassThrough in this way (without changing the actual behaviour of the code itself).